### PR TITLE
Update org.onlyoffice.desktopeditors.json

### DIFF
--- a/org.onlyoffice.desktopeditors.json
+++ b/org.onlyoffice.desktopeditors.json
@@ -46,8 +46,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-5.4.2/onlyoffice-desktopeditors-x64.tar.gz",
-                    "sha256": "41a36c030746e05a4556af930b15419ac94aaf7ba3f0b95ec99aa0f339dd050f",
+                    "url": "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-5.5.1/onlyoffice-desktopeditors-x64.tar.gz",
+                    "sha256": "0d1c0e5601592977e66e39dfa901532845408c5402f5e93f2f3875efacea52ce",
                     "strip-components": 0
                 },
                 {


### PR DESCRIPTION
Updated Onlyoffice to 5.5.1, to match upstream.