### PR TITLE
OnlyOffice is not wayland compatible

### DIFF
--- a/org.onlyoffice.desktopeditors.json
+++ b/org.onlyoffice.desktopeditors.json
@@ -10,7 +10,6 @@
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
-        "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
         "--filesystem=host",
@@ -19,6 +18,7 @@
         "--talk-name=org.gtk.vfs",
         "--talk-name=org.gtk.vfs.*",
         "--env=LC_ALL=C.UTF-8",
+        "--env=QT_QPA_PLATFORM=xcb",
         "--device=all"
     ],
     "modules": [


### PR DESCRIPTION
OnlyOffice is currently [not wayland compatible](https://github.com/ONLYOFFICE/DesktopEditors/issues/382) and wont work with Qt [wayland;xcb fallback](https://www.qt.io/blog/2018/05/29/whats-new-in-qt-5-11-for-the-wayland-platform-plugin). In order to not leak user setting of QT_QPA_PLATFORM this change always enforces xcb via an env var for the flatpak as well as removes wayland socket support advertising.

Closes: #57