### PR TITLE
Restrict permissions by using XDG desktop portals

### DIFF
--- a/org.onlyoffice.desktopeditors.json
+++ b/org.onlyoffice.desktopeditors.json
@@ -13,14 +13,12 @@
         "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
-        "--filesystem=host",
         "--filesystem=xdg-config/gtk-3.0",
-        "--filesystem=/tmp",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
         "--env=LC_ALL=C.UTF-8",
-        "--device=all"
+        "--device=dri"
     ],
     "modules": [
         {
@@ -56,7 +54,7 @@
                       "export LD_LIBRARY_PATH=./:$LD_LIBRARY_PATH",
                       "export CUSTOM_FONTS_PATH=/run/host/usr/local/share/fonts",
                       "cd /app/bin/opt/onlyoffice/desktopeditors/",
-                      "exec ./DesktopEditors \"$@\""
+                      "exec ./DesktopEditors --xdg-desktop-portal \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
Since 7.3.0, it is possible to use XDG desktop portals to open files. This means the "host" permissions for filesystems is not needed anymore.

Also removes the permissions for /tmp as unlike what is reported in #16, it is not needed anymore to ensure a single instance of OnlyOffice is running.

Restrict the permission to devices to "dri" (for hardware acceleration). Dunno why this was set to "all" in the first place.