### PR TITLE
Fixing Flathub's linter exception finish-args-contains-both-x11-and-fallback

### DIFF
--- a/org.onlyoffice.desktopeditors.json
+++ b/org.onlyoffice.desktopeditors.json
@@ -9,7 +9,7 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",


### PR DESCRIPTION
Hello OnlyOffice team,

I noticed a small misconfiguration in your manifest. Currently, you are using both `--socket=x11` and `--socket=wayland`. It is recommended to use `--socket=fallback-x11` in this case.

According to Flathub's linter rules, which you can find here: [Flathub Linter Rules](https://docs.flathub.org/docs/for-app-authors/linter#finish-args-contains-both-x11-and-fallback), this adjustment is advisable.

Additionally, here is a note from [Flatpak's documentation](https://docs.flatpak.org/en/latest/flatpak-command-reference.html):

> The fallback-x11 option makes the X11 socket available only if there is no Wayland socket. This option was introduced in 0.11.3. To support older Flatpak releases, specify both x11 and fallback-x11. The fallback-x11 option takes precedence when both are supported.

Thank you for your attention to this matter!