### PR TITLE
Enhance the flatpak manifest with x-checker-data for Version Monitoring

### DIFF
--- a/org.onlyoffice.desktopeditors.json
+++ b/org.onlyoffice.desktopeditors.json
@@ -44,7 +44,13 @@
                     "type": "archive",
                     "url": "http://download.onlyoffice.com/install/desktop/editors/linux/onlyoffice-desktopeditors-8.3.2-x64.tar.xz",
                     "sha256": "baeab8821c8bc05c08436d4c191a16a751cdae24274cbd1994e9cd944bc0d0fc",
-                    "strip-components": 0
+                    "strip-components": 0,
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/ONLYOFFICE/DesktopEditors/releases/latest",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": "\"http://download.onlyoffice.com/install/desktop/editors/linux/onlyoffice-desktopeditors-\\($version)-x64.tar.xz\""
+                    }
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Hello OnlyOffice team!

This PR enhances your manifest configuration by adding `x-checker-data`, which enables the [Flatpak External Data Checker](https://github.com/flathub-infra/flatpak-external-data-checker) (i.e., [flathubbot](https://github.com/flathubbot)) to monitor the version of your application. This integration ensures that a pull request will be created in this repository for every new version of your application, similar to [this one](https://github.com/flathub/com.rustdesk.RustDesk/pull/14).

In this pull request, I used your GitHub repository as the version source. However, if the version information is available through your website, please feel free to make changes or let me know if you would like me to update this pull request.

For more information on the Flatpak External Data Checker and its capabilities, please refer to the [documentation](https://github.com/flathub-infra/flatpak-external-data-checker?tab=readme-ov-file#changes-to-flatpak-manifests).

Thank you for considering this enhancement!