### PR TITLE
Updates for your README to reflect current Flathub's recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ And sometimes we skip major release if hotfix is coming
 
 ### Install via flathub.org
 
-1. Install flatpak runtime on your system according to [instruction](https://flatpak.org/setup/)
+1. Install `flatpak` runtime on your system according to [instruction](https://flathub.org/setup)
 2. Install application via
 
    ```shell script
@@ -30,8 +30,6 @@ And sometimes we skip major release if hotfix is coming
 
 ### Build application manually
 
-All steps tested on Ubuntu 18.04
-
 1. Clone this repo:
 
    ```shell script
@@ -39,21 +37,17 @@ All steps tested on Ubuntu 18.04
    cd org.onlyoffice.desktopeditors
    ```
 
-2. Install `flatpak` and `flatpak-builder` according to [instruction](https://flatpak.org/setup/)
-
-3. Install a runtime and the matching SDK
+2. Install `flatpak` runtime on your system according to [instruction](https://flathub.org/setup)
+3. Install `org.flatpak.Builder` according to [instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install)
 
    ```shell script
-   flatpak install flathub org.freedesktop.Platform//23.08 \
-                   org.freedesktop.Sdk//23.08 \
-                   io.atom.electron.BaseApp//20.08 \
-                   org.electronjs.Electron2.BaseApp//23.08
+   flatpak install -y flathub org.flatpak.Builder
    ```
 
 4. Build and install the application
 
    ```shell script
-   flatpak-builder build org.onlyoffice.desktopeditors.json --force-clean --install
+   flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo builddir org.onlyoffice.desktopeditors.json
    ```
 
 5. Run the application

--- a/README.md
+++ b/README.md
@@ -38,19 +38,25 @@ And sometimes we skip major release if hotfix is coming
    ```
 
 2. Install `flatpak` runtime on your system according to [instruction](https://flathub.org/setup)
-3. Install `org.flatpak.Builder` according to [instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install)
+3. Add the Flathub repo user-wide
+
+   ```shell script
+   flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+   ```
+
+4. Install `org.flatpak.Builder` according to [instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install)
 
    ```shell script
    flatpak install -y flathub org.flatpak.Builder
    ```
 
-4. Build and install the application
+5. Build and install the application
 
    ```shell script
    flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo builddir org.onlyoffice.desktopeditors.json
    ```
 
-5. Run the application
+6. Run the application
 
    ```shell script
    flatpak run org.onlyoffice.desktopeditors

--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ And sometimes we skip major release if hotfix is coming
    ```
 
 2. Install `flatpak` runtime on your system according to [instruction](https://flathub.org/setup)
-3. Add the Flathub repo user-wide
+3. Add the Flathub repo user-wide ([instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install))
 
    ```shell script
    flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
    ```
 
-4. Install `org.flatpak.Builder` according to [instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install)
+4. Install `org.flatpak.Builder` ([instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install))
 
    ```shell script
    flatpak install -y flathub org.flatpak.Builder
    ```
 
-5. Build and install the application
+5. Build and install the application ([instruction](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install))
 
    ```shell script
    flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo builddir org.onlyoffice.desktopeditors.json


### PR DESCRIPTION
Hello OnlyOffice team,

I noticed that the README in this repository is somewhat outdated, so I would like to propose some changes to align it with the latest recommendations from Flathub.

### What's Changed:
- The link for the current flatpak installation instructions has been updated to point to the Flathub website instead of the Flatpak site.
- The use of `flatpak-builder` is no longer recommended by Flathub. I have included new commands and instructions based on the updated guidelines: [Flathub Build and Install Instructions](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install).
- I removed the manual dependency installation step, as `org.flatpak.Builder` now automatically handles this based on the manifest.

I have verified that these new commands work correctly on Ubuntu 24.04.

Thank you for considering these changes! I believe they will enhance the clarity and usability of this README for your users.